### PR TITLE
feat(item's detail) Adding item's details page and check out feature

### DIFF
--- a/frontend/src/app/router.jsx
+++ b/frontend/src/app/router.jsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter } from 'react-router'
 import LoginPage from '../features/auth/pages/LoginPage'
 import RegisterPage from '../features/auth/pages/RegisterPage'
+import { detailPageLoader } from '../features/items/loaders/detailPageLoader'
 import DetailPage from '../features/items/pages/DetailPage'
 import HomePage, { homePageLoader } from '../features/items/pages/HomePage'
 import AppLayout, { appLayoutLoader } from '../layouts/AppLayout'
@@ -20,5 +21,9 @@ export const router = createBrowserRouter([
   },
   { path: '/register', element: <RegisterPage /> },
   { path: '/login', element: <LoginPage /> },
-  { path: '/item/:itemId', element: <DetailPage /> },
+  {
+    path: '/item/:itemId',
+    loader: detailPageLoader,
+    element: <DetailPage />,
+  },
 ])

--- a/frontend/src/features/items/api/checkOutItem.js
+++ b/frontend/src/features/items/api/checkOutItem.js
@@ -1,0 +1,9 @@
+import { api } from '../../../app/api'
+
+export function checkOutItem({ item_id, expected_return_date, notes }) {
+  return api.post('borrow-requests/create/', {
+    item_id,
+    expected_return_date,
+    notes,
+  })
+}

--- a/frontend/src/features/items/components/CheckOutModal.jsx
+++ b/frontend/src/features/items/components/CheckOutModal.jsx
@@ -1,0 +1,131 @@
+import { useMemo, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { checkOutItem as checkOut } from '../api/checkOutItem'
+
+export default function CheckOutModal({ item, onCancel }) {
+  const [loading, setLoading] = useState(false)
+  const [success, setSuccess] = useState(false)
+  const [errorMessages, setErrorMessages] = useState([])
+
+  // set the return date to two weeks from now
+  const returnDate = useMemo(() => {
+    const date = new Date()
+    date.setDate(date.getDate() + 14)
+    return date.toISOString()
+  }, [])
+
+  const {
+    register,
+    handleSubmit,
+    // formState: { errors },
+  } = useForm()
+
+  const onSubmit = async (data) => {
+    setErrorMessages([])
+    setLoading(true)
+    try {
+      await checkOut({
+        item_id: item.id,
+        expected_return_date: returnDate,
+        notes: data.notes || '',
+      })
+      setSuccess(true)
+    }
+    catch (err) {
+      const errorData = err.response?.data
+      if (errorData) {
+        const errorMessages = Object.values(errorData).flat()
+        setErrorMessages(errorMessages)
+      }
+    }
+    finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex justify-center items-center backdrop-blur-sm bg-black/30"
+      onClick={onCancel}
+    >
+      <div
+        className="bg-white p-5 rounded-2xl shadow-xl w-[30%] min-h-[90%] flex flex-col justify-center items-center gap-5"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="text-center mb-4">
+          <p>You're about to check out</p>
+          <h1 className="font-display-5xl">{item.title}</h1>
+        </div>
+
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className="w-[80%] flex flex-col gap-3"
+        >
+          {/* Return date is shown as read-only text */}
+          <div className="flex flex-col gap-1">
+            <label htmlFor="return-date" className="font-sans">
+              Return Date
+            </label>
+            <input
+              id="return-date"
+              type="text"
+              className="block border-1 border-stroke-weak px-4 py-3 rounded-xl bg-gray-300 cursor-not-allowed"
+              value={new Date(returnDate).toLocaleDateString()}
+              disabled
+              readOnly
+            />
+            <p className="text-xs text-gray-500">
+              Return date is set to
+              {' '}
+              <b>2 weeks</b>
+              {' '}
+              from now.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label htmlFor="notes" className="font-sans">
+              Notes
+            </label>
+            <textarea
+              id="notes"
+              placeholder="Add some notes..."
+              {...register('notes')}
+              rows={4}
+              className="block border-1 border-stroke-weak px-4 py-3 rounded-xl focus:outline-stroke-strong resize-none"
+            />
+          </div>
+
+          {errorMessages.length > 0 && (
+            <div className="text-red text-sm">
+              {errorMessages.map(msg => (
+                <p key={msg}>{msg}</p>
+              ))}
+            </div>
+          )}
+
+          <div className="flex flex-col gap-4">
+            <button
+              type="submit"
+              className="font-sans-lg-upper flex justify-center items-center gap-2 py-3 w-full max-w-[400px] bg-lavender-500 text-white rounded-md cursor-pointer"
+              disabled={loading || success}
+            >
+              {success
+                ? 'Checked Out!'
+                : loading
+                  ? 'Checking Out...'
+                  : 'Confirm'}
+            </button>
+            <button
+              type="button"
+              onClick={onCancel}
+              className="font-sans-lg-upper flex justify-center items-center gap-2 py-3 w-full max-w-[400px] bg-[#F2ECF4] rounded-md cursor-pointer"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/items/loaders/detailPageLoader.js
+++ b/frontend/src/features/items/loaders/detailPageLoader.js
@@ -1,0 +1,6 @@
+import { getItemDetails } from '../api/getItemDetails'
+
+export async function detailPageLoader({ params }) {
+  const respond = await getItemDetails(params.itemId)
+  return { item: respond.data }
+}

--- a/frontend/src/features/items/loaders/detailPageLoader.js
+++ b/frontend/src/features/items/loaders/detailPageLoader.js
@@ -1,6 +1,13 @@
+import { getProfile } from '../../profile/api/getProfile'
 import { getItemDetails } from '../api/getItemDetails'
 
 export async function detailPageLoader({ params }) {
-  const respond = await getItemDetails(params.itemId)
-  return { item: respond.data }
+  const [itemResponse, profileResponse] = await Promise.all([
+    getItemDetails(params.itemId),
+    getProfile(),
+  ])
+  return {
+    item: itemResponse.data,
+    profile: profileResponse.status === 403 ? null : profileResponse.data,
+  }
 }

--- a/frontend/src/features/items/pages/DetailPage.jsx
+++ b/frontend/src/features/items/pages/DetailPage.jsx
@@ -1,11 +1,18 @@
 import { Icon } from '@iconify-icon/react/dist/iconify.mjs'
+import { useState } from 'react'
 import { useLoaderData } from 'react-router'
 import Tags from '../../../components/Tags'
+import CheckOutModal from '../components/CheckOutModal'
 import useImageSlider from '../hooks/useImageSlider'
 
 function DetailPage() {
-  const { item } = useLoaderData()
+  const { item, profile } = useLoaderData()
   const images = item.image_urls || []
+  const isOwner = profile?.id === item.owner.id
+  const [isModalOpen, setIsModalOpen] = useState(false)
+
+  const openModal = () => setIsModalOpen(true)
+  const closeModal = () => setIsModalOpen(false)
 
   const { currentIndex, prevImage, nextImage, showImage }
     = useImageSlider(images)
@@ -113,49 +120,78 @@ function DetailPage() {
               <p>
                 {item.description}
               </p>
-              <p>
-                This is one of my treasures. So, please handle with care, avoid
-                bending. Thank you!
-              </p>
             </div>
           </div>
 
-          <div className="">
-            <div className="flex flex-row items-center gap-4">
-              <button
-                type="button"
-                className="font-sans-lg-upper flex justify-center items-center gap-2 py-3 w-full max-w-[400px] bg-lavender-500 text-white rounded-md"
-              >
-                <Icon icon="heroicons:shopping-bag" className="text-2xl" />
-                <span>Check out</span>
-              </button>
-              <button
-                type="button"
-                className="flex justify-center items-center p-3 bg-lavender-500 text-white rounded-md"
-              >
-                <Icon
-                  icon="heroicons:chat-bubble-oval-left-ellipsis"
-                  className="text-2xl"
-                />
-              </button>
-              <button
-                type="button"
-                className="flex justify-center items-center p-3 bg-[#F2ECF4] rounded-md"
-              >
-                <Icon icon="heroicons:heart" className="text-2xl" />
-              </button>
+          {!isOwner && (
+            <div className="">
+              <div className="flex flex-row items-center gap-4">
+                <button
+                  type="button"
+                  className="font-sans-lg-upper flex justify-center items-center gap-2 py-3 w-full max-w-[400px] bg-lavender-500 text-white rounded-md cursor-pointer"
+                  onClick={openModal}
+                >
+                  <Icon icon="heroicons:shopping-bag" className="text-2xl" />
+                  <span>Check out</span>
+                </button>
+                <button
+                  type="button"
+                  className="flex justify-center items-center p-3 bg-lavender-500 text-white rounded-md"
+                >
+                  <Icon
+                    icon="heroicons:chat-bubble-oval-left-ellipsis"
+                    className="text-2xl"
+                  />
+                </button>
+                <button
+                  type="button"
+                  className="flex justify-center items-center p-3 bg-[#F2ECF4] rounded-md"
+                >
+                  <Icon icon="heroicons:heart" className="text-2xl" />
+                </button>
+              </div>
+              <div className="flex flex-row items-center gap-1 mt-2">
+                <Icon icon="heroicons:information-circle" className="text-xl" />
+                <span>
+                  You can lend this item for
+                  {' '}
+                  <b>2 weeks</b>
+                  .
+                </span>
+              </div>
             </div>
-            <div className="flex flex-row items-center gap-1 mt-2">
-              <Icon icon="heroicons:information-circle" className="text-xl" />
-              <span>
-                You can lend this item for
-                {' '}
-                <b>2 weeks</b>
-                .
-              </span>
+          )}
+
+          {isOwner && (
+            <div className="">
+              <div className="flex flex-row items-center gap-4">
+                <button
+                  type="button"
+                  className="font-sans-lg-upper flex justify-center items-center gap-2 py-3 w-full max-w-[400px] bg-red text-white rounded-md"
+                >
+                  <Icon icon="heroicons:trash" className="text-2xl" />
+                  <span>Delete</span>
+                </button>
+                <button
+                  type="button"
+                  className="font-sans-lg-upper flex justify-center items-center gap-2 py-3 w-full max-w-[400px] bg-lavender-500 text-white rounded-md"
+                >
+                  <Icon
+                    icon="heroicons:pencil-square"
+                    className="text-2xl"
+                  />
+                  <span>Edit</span>
+                </button>
+              </div>
             </div>
-          </div>
+          )}
         </div>
+        {isModalOpen && (
+          <CheckOutModal
+            item={item}
+            onCancel={closeModal}
+          />
+        )}
       </div>
     </div>
   )

--- a/frontend/src/features/items/pages/DetailPage.jsx
+++ b/frontend/src/features/items/pages/DetailPage.jsx
@@ -1,14 +1,14 @@
 import { Icon } from '@iconify-icon/react/dist/iconify.mjs'
+import { useLoaderData } from 'react-router'
 import Tags from '../../../components/Tags'
 import useImageSlider from '../hooks/useImageSlider'
-import Navbar from '../../../components/Navbar'
 
 function DetailPage() {
-  // get images from api later
-  const images = ['/purpleBook.png', '/grayBook.png']
+  const { item } = useLoaderData()
+  const images = item.image_urls || []
 
-  const { currentIndex, prevImage, nextImage, showImage } =
-    useImageSlider(images)
+  const { currentIndex, prevImage, nextImage, showImage }
+    = useImageSlider(images)
 
   return (
     <div className="min-h-[100dvh]">
@@ -37,7 +37,7 @@ function DetailPage() {
               src={images[currentIndex]}
               alt={`Image ${currentIndex + 1}`}
               className="h-[70%]"
-            ></img>
+            />
             {/* We can decide later on if the image should be covering the entire box or kept like this */}
 
             <button
@@ -70,7 +70,7 @@ function DetailPage() {
                   className={`rounded-lg py-6 px-10 w-[160px] transition-colors cursor-pointer ${
                     index === currentIndex ? 'bg-[#D3D3F1]' : 'bg-gray-200'
                   }`}
-                ></img>
+                />
               </button>
             ))}
           </div>
@@ -89,28 +89,29 @@ function DetailPage() {
                 <span className="font-sans-base font-bold">Smug Cat</span>
               </div>
 
-              <p className="text-stroke-strong">2 available</p>
+              <p className="text-stroke-strong">
+                {item?.number_of_items}
+                {' '}
+                available
+              </p>
             </div>
 
             <div className="py-4">
-              {/* Render name, author, tags, description, owner and owner's notes later */}
               <h1 className="font-display-5xl">
-                Book In Purple by Book Author
+                {item?.title}
               </h1>
               <div className="flex gap-2 mt-4">
-                <Tags type="condition" label="new" />
-                <Tags type="category" label="book" />
-                <Tags type="genre" label="genre" />
-                <Tags type="genre" label="genre" />
+                <Tags type="condition" label={item.condition} />
+                <Tags type="category" label={item.category} />
+                {item.tags.map(tag => (
+                  <Tags key={tag} type="genre" label={tag} />
+                ))}
               </div>
             </div>
 
             <div className="flex flex-col gap-8 mt-10">
               <p>
-                A book in purple. Yep. You've guessed it! It's a book all about
-                purple: purple plants, purple animals, purple houses, every
-                purple existence that exists in our universe! You can find all
-                the purple in this book!
+                {item.description}
               </p>
               <p>
                 This is one of my treasures. So, please handle with care, avoid
@@ -147,7 +148,10 @@ function DetailPage() {
             <div className="flex flex-row items-center gap-1 mt-2">
               <Icon icon="heroicons:information-circle" className="text-xl" />
               <span>
-                You can lend this item for <b>2 weeks</b>.
+                You can lend this item for
+                {' '}
+                <b>2 weeks</b>
+                .
               </span>
             </div>
           </div>

--- a/frontend/src/features/items/pages/DetailPage.jsx
+++ b/frontend/src/features/items/pages/DetailPage.jsx
@@ -90,7 +90,7 @@ function DetailPage() {
               </div>
 
               <p className="text-stroke-strong">
-                {item?.number_of_items}
+                {item.number_of_items}
                 {' '}
                 available
               </p>
@@ -98,7 +98,7 @@ function DetailPage() {
 
             <div className="py-4">
               <h1 className="font-display-5xl">
-                {item?.title}
+                {item.title}
               </h1>
               <div className="flex gap-2 mt-4">
                 <Tags type="condition" label={item.condition} />


### PR DESCRIPTION
## Item's Details Page
- Dynamically rendering data from the API (except user profile)
- Item owner can't see the "Check Out" button but "Edit" and "Delete"
### Item owner's view
<img width="1919" height="872" alt="image" src="https://github.com/user-attachments/assets/706af92c-414f-49e0-8aa9-afd6c9cc6a00" />

### Non owner's view
<img width="1919" height="875" alt="image" src="https://github.com/user-attachments/assets/206ba81f-aa19-40de-ac25-48bb078f18a4" />


## Checking Out The Item
- Sending a request with a modal pop up
<img width="1919" height="871" alt="image" src="https://github.com/user-attachments/assets/7164d32a-f6d1-4f0f-861d-8ad1bfe2a789" />

### If succeed
<img width="1919" height="873" alt="Screenshot 2025-07-26 123806" src="https://github.com/user-attachments/assets/d5f6e4fe-3f1c-4a85-a7f9-29383df06115" />

### If failed
<img width="1919" height="874" alt="Screenshot 2025-07-26 123829" src="https://github.com/user-attachments/assets/eb045a00-c0c8-41a4-a6b7-e2626da742c2" />


